### PR TITLE
Remove pink tint from background colors

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/Themes/ColorScheme/Dark.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/Themes/ColorScheme/Dark.xaml
@@ -2,23 +2,23 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:po="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options">
     <!-- Black -->
-    <Color x:Key="Toggl.BlackColor">#FDE5EC</Color>
+    <Color x:Key="Toggl.BlackColor">#D6D6D6</Color>
     <!-- Dark Gray -->
-    <Color x:Key="Toggl.DarkGrayColor">#D5D0D8</Color>
+    <Color x:Key="Toggl.DarkGrayColor">#B9B9BD</Color>
     <!-- Gray -->
-    <Color x:Key="Toggl.GrayColor">#ABA0AF</Color>
+    <Color x:Key="Toggl.GrayColor">#A5A5A8</Color>
     <!-- Grayish -->
-    <Color x:Key="Toggl.Grayish1Color">#766C7B</Color>
+    <Color x:Key="Toggl.Grayish1Color">#696A6B</Color>
     <!-- Grayish -->
-    <Color x:Key="Toggl.Grayish2Color">#6B5A74</Color>
+    <Color x:Key="Toggl.Grayish2Color">#858585</Color>
     <!-- Light Gray -->
-    <Color x:Key="Toggl.LightGrayColor">#463350</Color>
+    <Color x:Key="Toggl.LightGrayColor">#3B3B3B</Color>
     <!-- Off-white -->
-    <Color x:Key="Toggl.OffWhiteColor">#0B030E</Color>
+    <Color x:Key="Toggl.OffWhiteColor">#0F0F0F</Color>
     <!-- White -->
-    <Color x:Key="Toggl.WhiteColor">#1B0A24</Color>
+    <Color x:Key="Toggl.WhiteColor">#1F1F1F</Color>
     <!-- Off-white -->
-    <Color x:Key="Toggl.SelectionElements.BackgroundColor">#180A1E</Color>
+    <Color x:Key="Toggl.SelectionElements.BackgroundColor">#141414</Color>
 
     <Color x:Key="Toggl.AccentColor">#DF68D0</Color>
     <Color x:Key="Toggl.AccentColorPlusOne">#B655AA</Color>
@@ -40,17 +40,17 @@
     <Color x:Key="Toggl.SecondaryAccentColorThirtyPercentDarker">#B36055</Color>
 
     <!-- Toggl.BlackColor*0.05 on Toggl.WhiteColor background -->
-    <Color x:Key="Toggl.FivePercentBlackColor">#26152E</Color>
-    <Color x:Key="Toggl.TransparentBlackColor">#0026152E</Color>
+    <Color x:Key="Toggl.FivePercentBlackColor">#2D2D2D</Color>
+    <Color x:Key="Toggl.TransparentBlackColor">#002D2D2D</Color>
 
     <!-- A combination of Toggl.LightGrayColor and 25% Toggl.BlackColor: -->
-    <SolidColorBrush x:Key="Toggl.Button.Primary.MouseOverBorder" Color="#735F77" po:Freeze="True" />
+    <SolidColorBrush x:Key="Toggl.Button.Primary.MouseOverBorder" Color="#5F5F5F" po:Freeze="True" />
     <!-- A combination of Toggl.LightGrayColor and 5% Toggl.BlackColor: -->
-    <SolidColorBrush x:Key="Toggl.Button.Primary.MouseOverBackground" Color="#4F3C57" po:Freeze="True" />
+    <SolidColorBrush x:Key="Toggl.Button.Primary.MouseOverBackground" Color="#424242" po:Freeze="True" />
     <!-- A combination of Toggl.LightGrayColor and 10% Toggl.BlackColor: -->
-    <SolidColorBrush x:Key="Toggl.Button.Primary.PressedBackground" Color="#58455F" po:Freeze="True" />
+    <SolidColorBrush x:Key="Toggl.Button.Primary.PressedBackground" Color="#494949" po:Freeze="True" />
     <!-- A combination of Toggl.LightGrayColor and 30% Toggl.BlackColor: -->
-    <SolidColorBrush x:Key="Toggl.Button.Primary.PressedBorder" Color="#7D687F" po:Freeze="True" />
+    <SolidColorBrush x:Key="Toggl.Button.Primary.PressedBorder" Color="#656565" po:Freeze="True" />
 
     <!-- 5% Toggl.BlackColor on Toggl.WhiteColor background -->
     <SolidColorBrush x:Key="Toggl.TextBox.Timer.MouseOverBackground" Color="{StaticResource Toggl.FivePercentBlackColor}" po:Freeze="True" />

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/Themes/ColorScheme/Light.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/Themes/ColorScheme/Light.xaml
@@ -2,11 +2,11 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:po="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options">
     <!-- Black -->
-    <Color x:Key="Toggl.BlackColor">#2C1338</Color>
+    <Color x:Key="Toggl.BlackColor">#000000</Color>
     <!-- Dark Gray -->
-    <Color x:Key="Toggl.DarkGrayColor">#564360</Color>
+    <Color x:Key="Toggl.DarkGrayColor">#333333</Color>
     <!-- Gray -->
-    <Color x:Key="Toggl.GrayColor">#6B5A74</Color>
+    <Color x:Key="Toggl.GrayColor">#555555</Color>
     <!-- Grayish -->
     <Color x:Key="Toggl.Grayish1Color">#ACACAC</Color>
     <!-- Grayish -->
@@ -14,7 +14,7 @@
     <!-- Light Gray -->
     <Color x:Key="Toggl.LightGrayColor">#D9D9D9</Color>
     <!-- Off-white -->
-    <Color x:Key="Toggl.OffWhiteColor">#FEF9F8</Color>
+    <Color x:Key="Toggl.OffWhiteColor">#F3F4F5</Color>
     <!-- White -->
     <Color x:Key="Toggl.WhiteColor">#FFFFFF</Color>
     <!-- White -->
@@ -40,8 +40,8 @@
     <Color x:Key="Toggl.SecondaryAccentColorThirtyPercentDarker">#B36055</Color>
 
     <!-- Toggl.BlackColor*0.05 on White background -->
-    <Color x:Key="Toggl.FivePercentBlackColor">#F4F2F4</Color>
-    <Color x:Key="Toggl.TransparentBlackColor">#00F4F2F4</Color>
+    <Color x:Key="Toggl.FivePercentBlackColor">#F2F2F2</Color>
+    <Color x:Key="Toggl.TransparentBlackColor">#00F2F2F2</Color>
 
     <!-- A combination of Toggl.LightGrayColor and 25% Black: -->
     <SolidColorBrush x:Key="Toggl.Button.Primary.MouseOverBorder" Color="#A4A4A4" po:Freeze="True" />


### PR DESCRIPTION
### 📒 Description
I changed the background colors back to the old ones, such that they are
more neutral again, but I kept the rebranding pink as accent color.
The changes are for dark and light mode.

### 🕶️ Types of changes
**Design Change**

### 🤯 List of changes
Remove pink tint from background colors

### 👫 Relationships
Got the old colors from:
Commit 5128248: Rebranding - Update Windows app colors and icons (win)

### 🔎 Review hints
I am usually using the dark mode, so I won't really see any issues with the light mode. Still, I changed the colors for light mode and quickly checked it out.

