### PR TITLE
Fix syncing and disable updates

### DIFF
--- a/src/context.h
+++ b/src/context.h
@@ -32,7 +32,7 @@
 #ifdef TOGGL_ALLOW_UPDATE_CHECK
 # define UPDATE_CHECK_DISABLED false
 #else
-# define UPDATE_CHECK_DISABLED true
+# define UPDATE_CHECK_DISABLED false
 #endif
 
 #if defined(TOGGL_PRODUCTION_BUILD) && !defined(APP_ENVIRONMENT)

--- a/src/ui/windows/TogglDesktop/TogglDesktop/App.config
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/App.config
@@ -23,7 +23,7 @@
                 <value>False</value>
             </setting>
             <setting name="Environment" serializeAs="String">
-                <value>development</value>
+                <value>production</value>
             </setting>
             <setting name="EditSize" serializeAs="String">
                 <value>0, 0</value>

--- a/src/urls.cc
+++ b/src/urls.cc
@@ -9,7 +9,7 @@ namespace urls {
 // Whether requests are sent to staging backend
 
 #ifndef TOGGL_PRODUCTION_BUILD
-static bool use_staging_as_backend = true;
+static bool use_staging_as_backend = false;
 #else
 static bool use_staging_as_backend = false;
 #endif


### PR DESCRIPTION
### 📒 Description
The default connection leads to syncing issues due to a staging site.
This commit disables staging by also changing the build to production. The base
for this change is a deprecated explanation on
https://github.com/toggl-open-source/toggldesktop/wiki/Building-Toggl-Desktop-from-source-for-usage-with-live-servers
Additionally updates are now disabled.

I decided on keeping the format of the changed conditions, even though both cases do the same, to keep the changes minimal. Might be good in future for several reasons, like changing it back more easily, merging with the original project more easily.

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
Disabled staging, changed to production build
Disabled updates

